### PR TITLE
Remove Sepolicy triggering neverallows

### DIFF
--- a/common/private/update_engine.te
+++ b/common/private/update_engine.te
@@ -1,1 +1,0 @@
-allow update_engine self:capability { dac_override dac_read_search sys_rawio };


### PR DESCRIPTION
These sepolicies causes neverallows triggers so it's better to remove these.